### PR TITLE
feat: test using docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+zig-cache/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 zig-cache/
+bin/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-zig-cache/
-bin/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,9 +31,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build test docker image
-        run: docker build -t foxwren-test .
-      - name: Run  tests
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx
+      - name: Build test image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          file: Dockerfile
+          push: false
+          tags: foxwren-test
+          cache-from: type=gha
+          cache-to: type=gha
+      - name: Run tests
         run: docker run foxwren-test
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ jobs:
         run: apt-get install wabt
       - name: Install xz
         run: apt-get install xz-utils
+      - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,22 +14,6 @@ jobs:
       - run: zig build test
   testsuite:
     runs-on: ubuntu-latest
-    container: ubuntu:20.10
-    steps:
-      - name: Update apt
-        run: apt update
-      - name: Install wabt
-        run: apt-get install wabt
-      - name: Install xz
-        run: apt-get install xz-utils
-      - uses: actions/checkout@v2
-      - uses: goto-bus-stop/setup-zig@v1
-        with:
-          version: master
-      - run: zig build --build-file test/build.zig --prefix ./
-      - run: bash test/run.sh
-  testsuite-docker:
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,6 @@ jobs:
         run: apt-get install wabt
       - name: Install xz
         run: apt-get install xz-utils
-      - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: master
@@ -31,6 +30,7 @@ jobs:
   testsuite-docker:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Build test docker image
         run: docker build -t foxwren-test .
       - name: Run  tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,9 +29,12 @@ jobs:
       - run: zig build --build-file test/build.zig --prefix ./
       - run: bash test/run.sh
   testsuite-docker:
-    runs:
-      using: docker
-      image: Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build test docker image
+        run: docker build -t foxwren-test .
+      - name: Run  tests
+        run: docker run foxwren-test
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
       - name: Build test image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@master
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Run tests
-        run: docker run foxwren-test
+        run: docker buildx run foxwren-test
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,6 +47,7 @@ jobs:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           file: Dockerfile
+          load: true
           push: false
           tags: foxwren-test
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,10 @@ jobs:
           version: master
       - run: zig build --build-file test/build.zig --prefix ./
       - run: bash test/run.sh
+  testsuite-docker:
+    runs:
+      using: docker
+      image: Dockerfile
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Run tests
-        run: docker buildx run foxwren-test
+        run: docker run foxwren-test
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,17 +42,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-single-buildx
       - name: Build test image
-        uses: docker/build-push-action@master
+        uses: docker/build-push-action@v2
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           file: Dockerfile
           push: false
           tags: foxwren-test
-          cache-from: type=gha
-          cache-to: type=gha
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Run tests
         run: docker run foxwren-test
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache        
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:20.10 AS base
+
+WORKDIR /base
+
+RUN apt-get update
+RUN apt-get install -y wget xz-utils
+
+RUN wget https://ziglang.org/builds/zig-linux-x86_64-0.8.0-dev.2064+da9da76e3.tar.xz
+RUN echo "926166f08046a582658f1e36f347ace00b4b7081dbaf0b43271da237a8cc2690  zig-linux-x86_64-0.8.0-dev.2064+da9da76e3.tar.xz" | sha256sum -c -
+RUN tar xf zig-linux-x86_64-0.8.0-dev.2064+da9da76e3.tar.xz
+RUN mv zig-linux-x86_64-0.8.0-dev.2064+da9da76e3 zig
+
+COPY src/ src/
+COPY test/ test/
+
+RUN ./zig/zig build --build-file test/build.zig --prefix ./
+
+RUN rm zig-linux-x86_64-0.8.0-dev.2064+da9da76e3.tar.xz
+
+FROM ubuntu:20.10 AS runner
+WORKDIR /base
+
+RUN apt-get update
+RUN apt-get install -y wabt
+
+COPY --from=base base/ ./
+
+ENTRYPOINT [ "bash", "test/run.sh" ]

--- a/README.md
+++ b/README.md
@@ -78,3 +78,19 @@ pub fn main() !void {
 - The project is very much alpha quality
 - The majority of the WebAssembly MVP spec testsuite passes (and is integrated into the CI) with a few exceptions and the type-checking validator code is not complete and so the `assert_invalid` tests are not included yet. See [#13](https://github.com/malcolmstill/foxwren/issues/13) and [#82](https://github.com/malcolmstill/foxwren/issues/82).
 - Currently, only the MVP spec is implemented without any extensions other than multiple-return values.
+
+## Running the testsuite
+
+The testsuite requires a relatively recent version of `wabt` (specifically the `wast2json` tool). A `Dockerfile` is provided to avoid manually installing the dependency:
+
+1. Build
+
+```
+docker build -t foxwren-test .
+```
+
+2. Run
+
+```
+docker run foxwren test
+```


### PR DESCRIPTION
# Purpose

Running the testsuite requires a particular version of `wabt` that can be awkward to install. If we use a docker image instead running the testsuite will be easier for people (assuming they have docker installed)