### PR TITLE
Operand stack size check on function call instead of instruction

### DIFF
--- a/src/common.zig
+++ b/src/common.zig
@@ -74,7 +74,7 @@ pub const Function = struct {
 pub const Global = struct {
     value_type: ValueType,
     mutability: Mutability,
-    code: ?Range,
+    start: ?usize,
     import: ?u32,
 };
 
@@ -95,7 +95,7 @@ pub const Element = struct {};
 
 pub const Segment = struct {
     index: u32,
-    offset: Range,
+    start: usize, // Initialisation code start
     count: u32, // Number of elements in data (useful when data is not []u8)
     data: []const u8,
 };

--- a/src/function.zig
+++ b/src/function.zig
@@ -34,15 +34,14 @@ pub const WasmError = error{
     GlobalIndexOutOfBounds,
     NegativeDenominator,
     Trap,
+    CheckStackSpace,
 };
 
 pub const Function = union(enum) {
     function: struct {
-        // locals: []const u8,
         locals_count: usize,
-        // code: []Instruction,
-        ip_start: usize,
-        ip_end: usize,
+        start: usize,
+        required_stack_space: usize,
         params: []const ValueType,
         results: []const ValueType,
         instance: usize,
@@ -55,7 +54,7 @@ pub const Function = union(enum) {
 };
 
 pub const Code = struct {
-    // locals: []const u8,
+    start: usize,
     locals_count: usize,
-    code: Range,
+    required_stack_space: usize,
 };

--- a/src/instruction.zig
+++ b/src/instruction.zig
@@ -232,10 +232,11 @@ pub const Instruction = union(RuntimeOpcode) {
         table: u32,
     },
     fast_call: struct {
-        ip_start: usize,
+        start: usize,
         locals: usize,
         params: usize,
         results: usize,
+        required_stack_space: usize,
     },
     drop: void,
     select: void,


### PR DESCRIPTION
# Description

- Moves operand stack overflow checks to granularity of function.
- Operand stack overflow check performed at function call
- Instructions that previously increased operand stack usage (and so performed an overflow check) no longer perform overflow checks
- Remove `ip_end`

```
fib(39) = 63245986

 Performance counter stats for './fib':

         12,042.78 msec task-clock:u              #    0.993 CPUs utilized          
                 0      context-switches:u        #    0.000 /sec                   
                 0      cpu-migrations:u          #    0.000 /sec                   
                22      page-faults:u             #    1.827 /sec                   
    37,726,320,071      cycles:u                  #    3.133 GHz                      (28.57%)
    10,444,544,015      stalled-cycles-frontend:u #   27.69% frontend cycles idle     (28.58%)
    72,526,786,598      instructions:u            #    1.92  insn per cycle         
                                                  #    0.14  stalled cycles per insn  (35.73%)
     6,511,471,789      branches:u                #  540.695 M/sec                    (35.70%)
       357,093,650      branch-misses:u           #    5.48% of all branches          (35.73%)
    32,574,458,032      L1-dcache-loads:u         #    2.705 G/sec                    (28.56%)
           635,772      L1-dcache-load-misses:u   #    0.00% of all L1-dcache accesses  (14.28%)
           182,340      LLC-loads:u               #   15.141 K/sec                    (14.27%)
   <not supported>      LLC-load-misses:u                                           
   <not supported>      L1-icache-loads:u                                           
           318,137      L1-icache-load-misses:u                                       (21.42%)
    32,541,074,702      dTLB-loads:u              #    2.702 G/sec                    (21.41%)
             6,978      dTLB-load-misses:u        #    0.00% of all dTLB cache accesses  (14.29%)
           106,152      iTLB-loads:u              #    8.815 K/sec                    (14.29%)
           207,718      iTLB-load-misses:u        #  195.68% of all iTLB cache accesses  (21.45%)
   <not supported>      L1-dcache-prefetches:u                                      
           313,428      L1-dcache-prefetch-misses:u #   26.026 K/sec                    (28.57%)

      12.123309202 seconds time elapsed

      11.931573000 seconds user
       0.036801000 seconds sys
```